### PR TITLE
Identity Contract: `create_identity`, `add_address` and boilerplate for other required functions 

### DIFF
--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -1,6 +1,9 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use ink::storage::traits::StorageLayout;
+use ink::{
+	prelude::{string::String, vec::Vec},
+	storage::traits::StorageLayout,
+};
 
 /// Each identity will be associated with a unique identifier called `IdentityNo`.
 pub type IdentityNo = u64;
@@ -11,7 +14,16 @@ pub type IdentityNo = u64;
 pub type Address = Vec<u8>;
 
 /// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
-pub type Network = String;
+#[derive(scale::Encode, scale::Decode, Debug)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
+pub enum Network {
+	/// Polkadot network
+	Polkadot(String),
+	/// Kusama network
+	Kusama(String),
+	/// Rococo network
+	Rococo(String),
+}
 
 #[derive(scale::Encode, scale::Decode, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -25,17 +25,17 @@ pub struct IdentityInfo {
 
 impl IdentityInfo {
 	/// Adds an address for the given network
-	pub fn add_address(network: Network, address: Address) {
+	pub fn add_address(&mut self, network: Network, address: Address) {
 		// TODO:
 	}
 
 	/// Updates the address of the given network
-	pub fn update_address(network: Network, new_address: Address) {
+	pub fn update_address(&mut self, network: Network, new_address: Address) {
 		// TODO:
 	}
 
 	/// Remove address of the given network
-	pub fn remove_address(network: Network) {
+	pub fn remove_address(&mut self, network: Network) {
 		// TODO:
 	}
 }
@@ -69,7 +69,7 @@ mod identity {
 		#[ink(message)]
 		/// Create an identity and returns the `IdentityNo`
 		/// A user can only create one identity
-		pub fn create_identity(&self) -> IdentityNo {
+		pub fn create_identity(&mut self) -> IdentityNo {
 			// TODO: Check if the caller already owns an identity
 
 			// Generate a new IdentityNo
@@ -86,25 +86,25 @@ mod identity {
 
 		#[ink(message)]
 		/// Adds an address for a given network
-		pub fn add_address(&self, network: Network, address: Address) {
+		pub fn add_address(&mut self, network: Network, address: Address) {
 			// TODO:
 		}
 
 		#[ink(message)]
 		/// Updates the address of the given network
-		pub fn update_address(&self, network: Network, address: Address) {
+		pub fn update_address(&mut self, network: Network, address: Address) {
 			// TODO:
 		}
 
 		#[ink(message)]
 		/// Removes the address by network
-		pub fn remove_address(&self, network: Network) {
+		pub fn remove_address(&mut self, network: Network) {
 			// TODO:
 		}
 
 		#[ink(message)]
 		/// Removes an identity
-		pub fn remove_identity(&self, identity_no: IdentityNo) {
+		pub fn remove_identity(&mut self, identity_no: IdentityNo) {
 			// TODO:
 		}
 	}

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -1,14 +1,51 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use ink::storage::traits::StorageLayout;
+
+/// Each identity will be associated with a unique identifier called `IdentityNo`.
+pub type IdentityNo = u64;
+
+/// We want to keep the address type very generic since we want to support any
+/// address format. We won't actually keep the addresses in the contract itself.
+/// Before storing them, we'll encrypt them to ensure privacy.
+pub type Address = Vec<u8>;
+
+/// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
+#[derive(scale::Encode, scale::Decode, Debug)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
+pub enum Network {
+	/// Polkadot network
+	Polkadot(String),
+	/// Kusama network
+	Kusama(String),
+	/// Rococo network
+	Rococo(String),
+}
+
+#[derive(scale::Encode, scale::Decode, Debug)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
+pub struct IdentityInfo {
+	/// Each address is associated with a specific blockchain.
+	addresses: Vec<(Network, Address)>,
+}
+
 #[ink::contract]
 mod identity {
+	use super::*;
+	use ink::storage::Mapping;
+
 	#[ink(storage)]
-	pub struct Identity {}
+	#[derive(Default)]
+	pub struct Identity {
+		number_to_identity: Mapping<IdentityNo, IdentityInfo>,
+		owner_of: Mapping<IdentityNo, AccountId>,
+		identity_of: Mapping<AccountId, IdentityNo>,
+	}
 
 	impl Identity {
 		#[ink(constructor)]
 		pub fn new() -> Self {
-			Identity {}
+			Default::default()
 		}
 
 		#[ink(message)]

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -14,16 +14,7 @@ pub type IdentityNo = u64;
 pub type Address = Vec<u8>;
 
 /// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
-#[derive(scale::Encode, scale::Decode, Debug)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
-pub enum Network {
-	/// Polkadot network
-	Polkadot(String),
-	/// Kusama network
-	Kusama(String),
-	/// Rococo network
-	Rococo(String),
-}
+pub type Network = String;
 
 #[derive(scale::Encode, scale::Decode, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -11,16 +11,7 @@ pub type IdentityNo = u64;
 pub type Address = Vec<u8>;
 
 /// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
-#[derive(scale::Encode, scale::Decode, Debug)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
-pub enum Network {
-	/// Polkadot network
-	Polkadot(String),
-	/// Kusama network
-	Kusama(String),
-	/// Rococo network
-	Rococo(String),
-}
+pub type Network = String;
 
 #[derive(scale::Encode, scale::Decode, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -5,6 +5,14 @@ use ink::{
 	storage::traits::StorageLayout,
 };
 
+macro_rules! ensure {
+	( $x:expr, $y:expr $(,)? ) => {{
+		if !$x {
+			return Err($y)
+		}
+	}};
+}
+
 /// Each identity will be associated with a unique identifier called `IdentityNo`.
 pub type IdentityNo = u64;
 
@@ -16,17 +24,31 @@ pub type Address = Vec<u8>;
 /// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
 pub type Network = String;
 
-#[derive(scale::Encode, scale::Decode, Debug)]
+#[derive(scale::Encode, scale::Decode, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
 pub struct IdentityInfo {
 	/// Each address is associated with a specific blockchain.
 	addresses: Vec<(Network, Address)>,
 }
 
+#[derive(scale::Encode, scale::Decode, Debug, PartialEq)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Error {
+	NotAllowed,
+	IdentityDoesntExist,
+	AddressAlreadyAdded,
+}
+
 impl IdentityInfo {
 	/// Adds an address for the given network
-	pub fn add_address(&mut self, network: Network, address: Address) {
-		// TODO:
+	pub fn add_address(&mut self, network: Network, address: Address) -> Result<(), Error> {
+		ensure!(
+			self.addresses.clone().into_iter().find(|address| address.0 == network) == None,
+			Error::AddressAlreadyAdded
+		);
+		self.addresses.push((network, address));
+
+		Ok(())
 	}
 
 	/// Updates the address of the given network
@@ -51,8 +73,10 @@ mod identity {
 		number_to_identity: Mapping<IdentityNo, IdentityInfo>,
 		owner_of: Mapping<IdentityNo, AccountId>,
 		identity_of: Mapping<AccountId, IdentityNo>,
-		total_identity: u64,
+		identity_count: u64,
 	}
+
+	// TODO: Add events
 
 	impl Identity {
 		#[ink(constructor)]
@@ -60,34 +84,41 @@ mod identity {
 			Default::default()
 		}
 
-		// TODO: remove this
 		#[ink(message)]
-		pub fn foo(&self) -> u32 {
-			42
-		}
+		/// Creates an identity and returns the `IdentityNo` A user can only
+		/// create one identity.
+		pub fn create_identity(&mut self) -> Result<IdentityNo, Error> {
+			let caller = self.env().caller();
 
-		#[ink(message)]
-		/// Create an identity and returns the `IdentityNo`
-		/// A user can only create one identity
-		pub fn create_identity(&mut self) -> IdentityNo {
-			// TODO: Check if the caller already owns an identity
+			ensure!(self.identity_of.get(caller).is_none(), Error::NotAllowed);
 
-			// Generate a new IdentityNo
-			let new_id = self.total_identity;
+			let identity_no = self.identity_count;
 
-			// TODO: initialize IdentityInfo
-			// TODO: Associate the newly created IdentityInfo with required mappings
+			let new_identity: IdentityInfo = Default::default();
 
-			// Increase the number of identities
-			self.total_identity = self.total_identity + 1;
+			self.number_to_identity.insert(identity_no, &new_identity);
+			self.identity_of.insert(caller, &identity_no);
+			self.owner_of.insert(identity_no, &caller);
 
-			new_id
+			self.identity_count = self.identity_count.saturating_add(1);
+
+			Ok(identity_no)
 		}
 
 		#[ink(message)]
 		/// Adds an address for a given network
-		pub fn add_address(&mut self, network: Network, address: Address) {
-			// TODO:
+		pub fn add_address(&mut self, network: Network, address: Address) -> Result<(), Error> {
+			let caller = self.env().caller();
+			ensure!(self.identity_of.get(caller).is_some(), Error::NotAllowed);
+
+			let identity_no = self.identity_of.get(caller).unwrap();
+			let Some(mut identity_info) = self.number_to_identity.get(identity_no) else { return Err(Error::IdentityDoesntExist) };
+
+			identity_info.add_address(network, address)?;
+
+			self.number_to_identity.insert(identity_no, &identity_info);
+
+			Ok(())
 		}
 
 		#[ink(message)]
@@ -117,7 +148,31 @@ mod identity {
 		#[ink::test]
 		fn constructor_works() {
 			let identity = Identity::new();
-			assert_eq!(identity.foo(), 42);
+		}
+
+		#[ink::test]
+		fn identity_creation_works() {
+			let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+			let mut identity = Identity::new();
+
+			assert!(identity.create_identity().is_ok());
+
+			// Make sure all the storage values got properly updated.
+			assert_eq!(identity.identity_of.get(accounts.alice), Some(0));
+			assert_eq!(identity.owner_of.get(0), Some(accounts.alice));
+			assert_eq!(
+				identity.number_to_identity.get(0).unwrap(),
+				IdentityInfo { addresses: Default::default() }
+			);
+
+			// Not possible to create an identity twice.
+			assert_eq!(identity.create_identity(), Err(Error::NotAllowed));
+		}
+
+		#[ink::test]
+		fn add_address_works() {
+			// TODO
 		}
 	}
 

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -23,6 +23,23 @@ pub struct IdentityInfo {
 	addresses: Vec<(Network, Address)>,
 }
 
+impl IdentityInfo {
+	/// Adds an address for the given network
+	pub fn add_address(network: Network, address: Address) {
+		// TODO:
+	}
+
+	/// Updates the address of the given network
+	pub fn update_address(network: Network, new_address: Address) {
+		// TODO:
+	}
+
+	/// Remove address of the given network
+	pub fn remove_address(network: Network) {
+		// TODO:
+	}
+}
+
 #[ink::contract]
 mod identity {
 	use super::*;
@@ -34,6 +51,7 @@ mod identity {
 		number_to_identity: Mapping<IdentityNo, IdentityInfo>,
 		owner_of: Mapping<IdentityNo, AccountId>,
 		identity_of: Mapping<AccountId, IdentityNo>,
+		total_identity: u64,
 	}
 
 	impl Identity {
@@ -42,9 +60,52 @@ mod identity {
 			Default::default()
 		}
 
+		// TODO: remove this
 		#[ink(message)]
 		pub fn foo(&self) -> u32 {
 			42
+		}
+
+		#[ink(message)]
+		/// Create an identity and returns the `IdentityNo`
+		/// A user can only create one identity
+		pub fn create_identity(&self) -> IdentityNo {
+			// TODO: Check if the caller already owns an identity
+
+			// Generate a new IdentityNo
+			let new_id = self.total_identity;
+
+			// TODO: initialize IdentityInfo
+			// TODO: Associate the newly created IdentityInfo with required mappings
+
+			// Increase the number of identities
+			self.total_identity = self.total_identity + 1;
+
+			new_id
+		}
+
+		#[ink(message)]
+		/// Adds an address for a given network
+		pub fn add_address(&self, network: Network, address: Address) {
+			// TODO:
+		}
+
+		#[ink(message)]
+		/// Updates the address of the given network
+		pub fn update_address(&self, network: Network, address: Address) {
+			// TODO:
+		}
+
+		#[ink(message)]
+		/// Removes the address by network
+		pub fn remove_address(&self, network: Network) {
+			// TODO:
+		}
+
+		#[ink(message)]
+		/// Removes an identity
+		pub fn remove_identity(&self, identity_no: IdentityNo) {
+			// TODO:
 		}
 	}
 


### PR DESCRIPTION
This PR:
- adds all the necessary storage values that are needed in the identity contract.
- implements the `create_identity` function and covers it with tests
- implements the `add_address` function and covers it with tests
- adds unimplemented functions for identity management. These will be implemented in separate PRs

Part of: #2