### PR TITLE
`add_identity`: e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
 name = "address-book"
 version = "0.1.0"
 dependencies = [
+ "common",
  "identity",
  "ink",
  "ink_e2e",
@@ -527,6 +528,15 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "common"
+version = "0.1.0"
+dependencies = [
+ "ink",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -1423,6 +1433,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 name = "identity"
 version = "0.1.0"
 dependencies = [
+ "common",
  "ink",
  "ink_e2e",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
 name = "address-book"
 version = "0.1.0"
 dependencies = [
+ "identity",
  "ink",
  "ink_e2e",
  "parity-scale-codec",

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ cd contracts/identity/
 cargo contract build --release
 ```
 4. Run e2e tests:
+
+   **We should have `substrate-contracts-node` installed in the path to run e2e tests.**
 ```
 # In the root of the project
 cargo test --features e2e-tests

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,29 +1,24 @@
 [package]
-name = "identity"
+name = "common"
 version = "0.1.0"
 authors = ["Master Union <masteruniondoo@gmail.com>"]
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 ink = { version = "4.2.0", default-features = false }
-common = { path = "../../common", default-features = false }
-
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
-[dev-dependencies]
-ink_e2e = "4.2.0"
-
 [lib]
-path = "lib.rs"
+path = "src/lib.rs"
+crate-type = ["rlib"]
 
 [features]
 default = ["std"]
 std = [
     "ink/std",
-    "common/std",
     "scale/std",
     "scale-info/std",
 ]
-ink-as-dependency = []
-e2e-tests = []

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,0 +1,4 @@
+//! Types used in multiple contracts.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod types;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,3 @@
-//! Types used in multiple contracts.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod types;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod macros;
 pub mod types;

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -1,0 +1,8 @@
+#[macro_export]
+macro_rules! ensure {
+	( $x:expr, $y:expr $(,)? ) => {{
+		if !$x {
+			return Err($y)
+		}
+	}};
+}

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,4 +1,4 @@
-//! Types used in multiple contracts.
+//! Types used in the dotflow contracts.
 
 use ink::prelude::{string::String, vec::Vec};
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,0 +1,30 @@
+//! Types used in multiple contracts.
+
+use ink::prelude::{string::String, vec::Vec};
+
+#[cfg(feature = "std")]
+use ink::storage::traits::StorageLayout;
+
+/// Each identity is associated with a unique identifier called `IdentityNo`.
+pub type IdentityNo = u32;
+
+/// We want to keep the address type very generic since we want to support any
+/// address format. We won't actually keep the addresses in the contract itself.
+/// Before storing them, we'll encrypt them to ensure privacy.
+pub type NetworkAddress = Vec<u8>;
+
+/// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
+pub type NetworkId = u32;
+
+/// Used to represent the Ss58 Prefix of a Substrate chain.
+pub type Ss58Prefix = u16;
+
+#[derive(scale::Encode, scale::Decode, Debug, Default, PartialEq, Clone)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
+pub struct NetworkInfo {
+	/// Each address is associated with a specific blockchain.
+	pub name: String,
+	/// This is used on the frontend to ensure the user does not add an address
+	/// that is not valid on the network he specified.
+	pub ss58_prefix: Ss58Prefix,
+}

--- a/contracts/address-book/Cargo.toml
+++ b/contracts/address-book/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 ink = { version = "4.2.0", default-features = false }
+common = { path = "../../common", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
@@ -21,6 +22,7 @@ path = "lib.rs"
 default = ["std"]
 std = [
     "ink/std",
+    "common/std",
     "scale/std",
     "scale-info/std",
     "identity/std",

--- a/contracts/address-book/Cargo.toml
+++ b/contracts/address-book/Cargo.toml
@@ -12,6 +12,7 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 
 [dev-dependencies]
 ink_e2e = "4.2.0"
+identity = { path = "../identity", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]
 path = "lib.rs"
@@ -22,6 +23,7 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
+    "identity/std",
 ]
 ink-as-dependency = []
 e2e-tests = []

--- a/contracts/address-book/lib.rs
+++ b/contracts/address-book/lib.rs
@@ -78,6 +78,12 @@ mod address_book {
 		pub(crate) address: AccountId,
 	}
 
+	#[ink(event)]
+	pub struct IdentityAdded {
+		pub(crate) owner: AccountId,
+		pub(crate) identity: IdentityNo,
+	}
+
 	impl AddressBook {
 		/// Constructor
 		/// Instantiate with the address of `Identity` contract
@@ -146,6 +152,11 @@ mod address_book {
 			ensure!(identity.is_some(), Error::InvalidIdentityNo);
 
 			address_book.add_identity(identity_no, nickname)?;
+
+			ink::env::emit_event::<DefaultEnvironment, _>(IdentityAdded {
+				owner: caller,
+				identity: identity_no,
+			});
 
 			Ok(())
 		}

--- a/contracts/address-book/lib.rs
+++ b/contracts/address-book/lib.rs
@@ -92,7 +92,8 @@ mod address_book {
 			AddressBook { address_book_of: Default::default(), identity_contract }
 		}
 
-		/// Creates an address book for a user
+		/// Returns the address of the identity contract that is used by the
+		/// address book.
 		#[ink(message)]
 		pub fn identity_contract(&self) -> AccountId {
 			self.identity_contract

--- a/contracts/address-book/lib.rs
+++ b/contracts/address-book/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
+use ink::prelude::{vec::Vec};
 #[cfg(test)]
 mod tests;
 

--- a/contracts/address-book/lib.rs
+++ b/contracts/address-book/lib.rs
@@ -76,11 +76,14 @@ mod address_book {
 	}
 
 	impl AddressBook {
+		/// Constructor
+		/// Instantiate with the address of `Identity` contract
 		#[ink(constructor)]
 		pub fn new(identity_contract: AccountId) -> Self {
 			AddressBook { address_book_of: Default::default(), identity_contract }
 		}
 
+		/// Creates an address book for a user
 		#[ink(message)]
 		pub fn create_address_book(&mut self) -> Result<(), Error> {
 			let caller = self.env().caller();
@@ -94,6 +97,7 @@ mod address_book {
 			Ok(())
 		}
 
+		/// Removes the address book of a user
 		#[ink(message)]
 		pub fn remove_address_book(&mut self) -> Result<(), Error> {
 			let caller = self.env().caller();
@@ -107,6 +111,7 @@ mod address_book {
 			Ok(())
 		}
 
+		/// Adds an identity to the user's address book
 		#[ink(message)]
 		pub fn add_identity(
 			&mut self,
@@ -136,14 +141,26 @@ mod address_book {
 			Ok(())
 		}
 
+		/// Removes an identity from the user's address book
 		#[ink(message)]
 		pub fn remove_identity(&mut self, identity_no: IdentityNo) {
 			// TODO:
 		}
 
+		/// Update nickname of an identity
 		#[ink(message)]
 		pub fn update_nickname(&mut self, identity_no: IdentityNo, new_nickname: Option<Nickname>) {
 			// TODO:
+		}
+
+		/// Returns the identities stored in the address book of a user
+		#[ink(message)]
+		pub fn identities_of(&self, account: AccountId) -> Vec<IdentityRecord> {
+			if let Some(address_book) = self.address_book_of.get(account) {
+				address_book.identities
+			} else {
+				Vec::default()
+			}
 		}
 	}
 }

--- a/contracts/address-book/lib.rs
+++ b/contracts/address-book/lib.rs
@@ -2,7 +2,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use ink::prelude::{vec::Vec};
+use common::types::*;
+use ink::prelude::vec::Vec;
+
 #[cfg(test)]
 mod tests;
 
@@ -205,6 +207,27 @@ mod address_book {
 				.await
 				.return_value();
 			assert_eq!(get_identity_contract_result, identity_acc_id);
+
+			Ok(())
+		}
+
+		#[ink_e2e::test]
+		async fn add_identity_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+			let identity_constructor = IdentityRef::init_with_networks(vec![]);
+
+			let identity_acc_id = client
+				.instantiate("identity", &ink_e2e::alice(), identity_constructor, 0, None)
+				.await
+				.expect("instantiate failed")
+				.account_id;
+
+			let book_constructor = AddressBookRef::new(identity_acc_id);
+
+			let book_acc_id = client
+				.instantiate("address-book", &ink_e2e::alice(), book_constructor, 0, None)
+				.await
+				.expect("instantiate failed")
+				.account_id;
 
 			Ok(())
 		}

--- a/contracts/address-book/lib.rs
+++ b/contracts/address-book/lib.rs
@@ -2,22 +2,13 @@
 
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-use common::types::*;
+use common::{ensure, types::*};
 use ink::prelude::vec::Vec;
 
 #[cfg(test)]
 mod tests;
 
 mod types;
-
-#[macro_export]
-macro_rules! ensure {
-	( $x:expr, $y:expr $(,)? ) => {{
-		if !$x {
-			return Err($y)
-		}
-	}};
-}
 
 /// The maximum number of chars the nickname can hold.
 const NICKNAME_LENGTH_LIMIT: u8 = 16;

--- a/contracts/address-book/tests.rs
+++ b/contracts/address-book/tests.rs
@@ -47,13 +47,37 @@ fn remove_address_book_works() {
 	assert_eq!(book.remove_address_book(), Ok(()));
 }
 
+#[ink::test]
+fn add_identity_works() {
+	let DefaultAccounts::<DefaultEnvironment> { alice, .. } = get_default_accounts();
+	let identity_contract = get_identity_contract_address();
+	let mut book = AddressBook::new(identity_contract);
+
+	assert_eq!(book.add_identity(0, None), Err(Error::AddressBookDoesntExist));
+
+	assert_eq!(book.create_address_book(), Ok(()));
+
+	assert_eq!(book.add_identity(0, None), Err(Error::InvalidIdentityNo));
+
+	let long_nickname =
+		String::from_utf8(vec![b'a'; (NICKNAME_LENGTH_LIMIT + 1) as usize]).unwrap();
+	assert_eq!(book.add_identity(1, Some(long_nickname)), Err(Error::NickNameTooLong));
+
+	assert_eq!(book.add_identity(1, Some("nickname".to_string())), Ok(()));
+
+	assert_eq!(book.identities_of(alice), vec![(Some("nickname".to_string()), 1)]);
+}
+
 fn get_default_accounts() -> DefaultAccounts<DefaultEnvironment> {
 	default_accounts::<DefaultEnvironment>()
 }
 
 fn get_identity_contract_address() -> AccountId {
-	let DefaultAccounts::<DefaultEnvironment> { eve, .. } = get_default_accounts();
-	eve
+	AccountId::from([
+		0x7b, 0x02, 0xe6, 0x2d, 0x7a, 0xcc, 0x3b, 0x38, 0x35, 0x9e, 0x3d, 0x88, 0x77, 0x93, 0x60,
+		0x32, 0xf9, 0x22, 0x37, 0x57, 0x5e, 0x9a, 0xa6, 0xee, 0xd7, 0x35, 0x78, 0x68, 0x0d, 0xb1,
+		0x50, 0xd5,
+	])
 }
 
 #[cfg(all(test, feature = "e2e-tests"))]

--- a/contracts/address-book/tests.rs
+++ b/contracts/address-book/tests.rs
@@ -58,6 +58,3 @@ fn get_identity_contract_address() -> AccountId {
 		0x50, 0xd5,
 	])
 }
-
-#[cfg(all(test, feature = "e2e-tests"))]
-mod e2e_tests {}

--- a/contracts/address-book/tests.rs
+++ b/contracts/address-book/tests.rs
@@ -47,29 +47,6 @@ fn remove_address_book_works() {
 	assert_eq!(book.remove_address_book(), Ok(()));
 }
 
-#[ink::test]
-fn add_identity_works() {
-	let DefaultAccounts::<DefaultEnvironment> { alice, .. } = get_default_accounts();
-	let identity_contract = get_identity_contract_address();
-	let mut book = AddressBook::new(identity_contract);
-
-	assert_eq!(book.add_identity(0, None), Err(Error::AddressBookDoesntExist));
-
-	assert_eq!(book.create_address_book(), Ok(()));
-
-	assert_eq!(book.add_identity(0, None), Err(Error::InvalidIdentityNo));
-
-	let long_nickname =
-		String::from_utf8(vec![b'a'; (NICKNAME_LENGTH_LIMIT + 1) as usize]).unwrap();
-	assert_eq!(book.add_identity(1, Some(long_nickname)), Err(Error::NickNameTooLong));
-
-	assert_eq!(book.add_identity(1, Some("nickname".to_string())), Ok(()));
-
-	assert_eq!(book.identities_of(alice), vec![(Some("nickname".to_string()), 1)]);
-
-	assert_eq!(book.add_identity(1, None), Err(Error::IdentityAlreadyAdded));
-}
-
 fn get_default_accounts() -> DefaultAccounts<DefaultEnvironment> {
 	default_accounts::<DefaultEnvironment>()
 }

--- a/contracts/address-book/tests.rs
+++ b/contracts/address-book/tests.rs
@@ -66,6 +66,8 @@ fn add_identity_works() {
 	assert_eq!(book.add_identity(1, Some("nickname".to_string())), Ok(()));
 
 	assert_eq!(book.identities_of(alice), vec![(Some("nickname".to_string()), 1)]);
+
+	assert_eq!(book.add_identity(1, None), Err(Error::IdentityAlreadyAdded));
 }
 
 fn get_default_accounts() -> DefaultAccounts<DefaultEnvironment> {

--- a/contracts/address-book/types.rs
+++ b/contracts/address-book/types.rs
@@ -6,9 +6,6 @@ use ink::storage::traits::StorageLayout;
 
 use crate::*;
 
-/// Each identity is associated with a unique identifier called `IdentityNo`.
-pub type IdentityNo = u32;
-
 pub type Nickname = String;
 
 pub type IdentityRecord = (Option<Nickname>, IdentityNo);

--- a/contracts/address-book/types.rs
+++ b/contracts/address-book/types.rs
@@ -4,7 +4,7 @@ use ink::prelude::{string::String, vec::Vec};
 #[cfg(feature = "std")]
 use ink::storage::traits::StorageLayout;
 
-use crate::Error;
+use crate::*;
 
 /// Each identity is associated with a unique identifier called `IdentityNo`.
 pub type IdentityNo = u32;
@@ -29,7 +29,7 @@ impl AddressBookInfo {
 	) -> Result<(), Error> {
 		ensure!(
 			!self.identities.clone().into_iter().any(|address| address.1 == identity_no),
-			Error::AddressAlreadyAdded
+			Error::IdentityAlreadyAdded
 		);
 
 		self.identities.push((nickname, identity_no));

--- a/contracts/address-book/types.rs
+++ b/contracts/address-book/types.rs
@@ -11,6 +11,8 @@ pub type IdentityNo = u32;
 
 pub type Nickname = String;
 
+pub type IdentityRecord = (Option<Nickname>, IdentityNo);
+
 /// The address book struct that contains all the information that the address
 /// book contract needs.
 #[derive(scale::Encode, scale::Decode, Debug, Default, PartialEq, Clone)]
@@ -18,7 +20,7 @@ pub type Nickname = String;
 pub struct AddressBookInfo {
 	/// All the identities that are part of an address book. Each identity can
 	/// have an optional nickname.
-	pub(crate) identities: Vec<(Option<Nickname>, IdentityNo)>,
+	pub(crate) identities: Vec<IdentityRecord>,
 }
 
 impl AddressBookInfo {
@@ -31,6 +33,10 @@ impl AddressBookInfo {
 			!self.identities.clone().into_iter().any(|address| address.1 == identity_no),
 			Error::IdentityAlreadyAdded
 		);
+
+		if let Some(name) = nickname.clone() {
+			ensure!(name.len() <= NICKNAME_LENGTH_LIMIT as usize, Error::NickNameTooLong);
+		}
 
 		self.identities.push((nickname, identity_no));
 

--- a/contracts/address-book/types.rs
+++ b/contracts/address-book/types.rs
@@ -4,6 +4,8 @@ use ink::prelude::{string::String, vec::Vec};
 #[cfg(feature = "std")]
 use ink::storage::traits::StorageLayout;
 
+use crate::Error;
+
 /// Each identity is associated with a unique identifier called `IdentityNo`.
 pub type IdentityNo = u32;
 
@@ -20,8 +22,19 @@ pub struct AddressBookInfo {
 }
 
 impl AddressBookInfo {
-	pub fn add_identity(identity_no: IdentityNo, nickname: Option<Nickname>) {
-		// TODO:
+	pub fn add_identity(
+		&mut self,
+		identity_no: IdentityNo,
+		nickname: Option<Nickname>,
+	) -> Result<(), Error> {
+		ensure!(
+			!self.identities.clone().into_iter().any(|address| address.1 == identity_no),
+			Error::AddressAlreadyAdded
+		);
+
+		self.identities.push((nickname, identity_no));
+
+		Ok(())
 	}
 
 	pub fn remove_identity(identity_no: IdentityNo) {

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -8,16 +8,9 @@ mod tests;
 
 mod types;
 
-pub use self::identity::{Identity, IdentityRef};
+use common::ensure;
 
-#[macro_export]
-macro_rules! ensure {
-	( $x:expr, $y:expr $(,)? ) => {{
-		if !$x {
-			return Err($y)
-		}
-	}};
-}
+pub use self::identity::{Identity, IdentityRef};
 
 /// Encrypted addresses should never exceed this size limit.
 const ADDRESS_SIZE_LIMIT: usize = 128;

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -43,8 +43,8 @@ pub enum Error {
 mod identity {
 	use super::*;
 	use crate::types::*;
+	use common::types::{NetworkInfo, Ss58Prefix, *};
 	use ink::storage::Mapping;
-	use types::{NetworkInfo, Ss58Prefix};
 
 	/// Storage
 	#[ink(storage)]

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -8,6 +8,8 @@ mod tests;
 
 mod types;
 
+pub use self::identity::{Identity, IdentityRef};
+
 #[macro_export]
 macro_rules! ensure {
 	( $x:expr, $y:expr $(,)? ) => {{

--- a/contracts/identity/tests.rs
+++ b/contracts/identity/tests.rs
@@ -1,5 +1,6 @@
 //! Ink! integration tests convering the identity contract functionality.
 use crate::{identity::*, types::*, *};
+use common::types::*;
 
 use ink::env::{
 	test::{default_accounts, recorded_events, set_caller, DefaultAccounts},

--- a/contracts/identity/types.rs
+++ b/contracts/identity/types.rs
@@ -1,34 +1,11 @@
 //! Types used in the identity contract.
 
 use crate::{ensure, Error, ADDRESS_SIZE_LIMIT};
-use ink::prelude::{string::String, vec::Vec};
+use common::types::*;
+use ink::prelude::vec::Vec;
 
 #[cfg(feature = "std")]
 use ink::storage::traits::StorageLayout;
-
-/// Each identity is associated with a unique identifier called `IdentityNo`.
-pub type IdentityNo = u32;
-
-/// We want to keep the address type very generic since we want to support any
-/// address format. We won't actually keep the addresses in the contract itself.
-/// Before storing them, we'll encrypt them to ensure privacy.
-pub type NetworkAddress = Vec<u8>;
-
-/// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
-pub type NetworkId = u32;
-
-/// Used to represent the Ss58 Prefix of a Substrate chain.
-pub type Ss58Prefix = u16;
-
-#[derive(scale::Encode, scale::Decode, Debug, Default, PartialEq, Clone)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
-pub struct NetworkInfo {
-	/// Each address is associated with a specific blockchain.
-	pub(crate) name: String,
-	/// This is used on the frontend to ensure the user does not add an address
-	/// that is not valid on the network he specified.
-	pub(crate) ss58_prefix: Ss58Prefix,
-}
 
 #[derive(scale::Encode, scale::Decode, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]


### PR DESCRIPTION
Creates a new crate called `common` which at the moment only contains the types that are used by both the identity and address book contract.

This PR adds a new `e2e` test which ensures that the `add_identity` ink! message works correctly.

Closes: #52 