### PR TITLE
BREAKING | Identity contract: Refactoring

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -11,7 +11,7 @@ pub type IdentityNo = u32;
 /// We want to keep the address type very generic since we want to support any
 /// address format. We won't actually keep the addresses in the contract itself.
 /// Before storing them, we'll encrypt them to ensure privacy.
-pub type ChainAddress = Vec<u8>;
+pub type EncryptedAddress = Vec<u8>;
 
 /// Used to represent any blockchain in the Polkadot, Kusama or Rococo chain.
 pub type ChainId = u32;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -11,10 +11,10 @@ pub type IdentityNo = u32;
 /// We want to keep the address type very generic since we want to support any
 /// address format. We won't actually keep the addresses in the contract itself.
 /// Before storing them, we'll encrypt them to ensure privacy.
-pub type NetworkAddress = Vec<u8>;
+pub type ChainAddress = Vec<u8>;
 
-/// Used to represent any blockchain in the Polkadot, Kusama or Rococo network.
-pub type NetworkId = u32;
+/// Used to represent any blockchain in the Polkadot, Kusama or Rococo chain.
+pub type ChainId = u32;
 
 /// We currently support these two address types since XCM is also supporting
 /// only these ones.
@@ -27,16 +27,16 @@ pub enum AccountType {
 
 #[derive(scale::Encode, scale::Decode, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
-pub struct NetworkInfo {
-	/// We need to know the rpc url of each network otherwise we won't know how
+pub struct ChainInfo {
+	/// We need to know the rpc url of each chain otherwise we won't know how
 	/// to communicate with it.
 	pub rpc_urls: Vec<String>,
 	/// We need to know the address type when making XCM transfers.
 	pub account_type: AccountType,
 }
 
-impl NetworkInfo {
-	// Makes sure none of the network's urls exceed the size limit.
+impl ChainInfo {
+	// Makes sure none of the chain's urls exceed the size limit.
 	pub fn ensure_rpc_url_size_limit(&self, limit: usize) -> bool {
 		self.rpc_urls.iter().all(|url| url.len() <= limit)
 	}

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -296,11 +296,7 @@ mod identity {
 
 		/// Adds an address for a given chain
 		#[ink(message)]
-		pub fn add_address(
-			&mut self,
-			chain: ChainId,
-			address: ChainAddress,
-		) -> Result<(), Error> {
+		pub fn add_address(&mut self, chain: ChainId, address: ChainAddress) -> Result<(), Error> {
 			let caller = self.env().caller();
 
 			let identity_no = self.identity_of.get(caller).map_or(Err(Error::NotAllowed), Ok)?;
@@ -331,11 +327,8 @@ mod identity {
 			identity_info.update_address(chain, address.clone())?;
 			self.number_to_identity.insert(identity_no, &identity_info);
 
-			self.env().emit_event(AddressUpdated {
-				identity_no,
-				chain,
-				updated_address: address,
-			});
+			self.env()
+				.emit_event(AddressUpdated { identity_no, chain, updated_address: address });
 
 			Ok(())
 		}
@@ -381,10 +374,7 @@ mod identity {
 			ensure!(caller == self.admin, Error::NotAllowed);
 
 			// Ensure that the rpc url is not exceeding the length limit.
-			ensure!(
-				info.ensure_rpc_url_size_limit(CHAIN_RPC_URL_LIMIT),
-				Error::ChainRpcUrlTooLong
-			);
+			ensure!(info.ensure_rpc_url_size_limit(CHAIN_RPC_URL_LIMIT), Error::ChainRpcUrlTooLong);
 
 			let chain_id = self.chain_id_count;
 			self.chain_info_of.insert(chain_id, &info);
@@ -411,8 +401,7 @@ mod identity {
 			ensure!(caller == self.admin, Error::NotAllowed);
 
 			// Ensure that the given chain id exists
-			let mut info =
-				self.chain_info_of.get(chain_id).map_or(Err(Error::InvalidChain), Ok)?;
+			let mut info = self.chain_info_of.get(chain_id).map_or(Err(Error::InvalidChain), Ok)?;
 
 			// Ensure that the rpc url of the chain doesn't exceed length limit.
 			if let Some(rpc_url) = new_rpc_url {

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -204,16 +204,18 @@ mod identity {
 
 			// Iterate over all the chains provided and make sure that no
 			// fields are exceeding the length limits.
-			chain_ids.clone().into_iter().zip(chains.clone().into_iter()).for_each(
-				|(chain_id, chain)| {
+			chain_ids
+				.clone()
+				.into_iter()
+				.zip(chains.into_iter())
+				.for_each(|(chain_id, chain)| {
 					assert!(
 						chain.ensure_rpc_url_size_limit(CHAIN_RPC_URL_LIMIT),
 						"Chain rpc url is too long"
 					);
 					let chain_id = chain_id as ChainId;
 					chain_info_of.insert(chain_id, &chain);
-				},
-			);
+				});
 
 			let caller = Self::env().caller();
 			Self {

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -98,7 +98,7 @@ mod identity {
 		/// The chain on which a new address has been added.
 		pub(crate) chain: ChainId,
 		/// The newly added address.
-		pub(crate) address: ChainAddress,
+		pub(crate) address: EncryptedAddress,
 	}
 
 	#[ink(event)]
@@ -109,7 +109,7 @@ mod identity {
 		/// The chain on which the address has been updated.
 		pub(crate) chain: ChainId,
 		/// The updated address value.
-		pub(crate) updated_address: ChainAddress,
+		pub(crate) updated_address: EncryptedAddress,
 	}
 
 	#[ink(event)]
@@ -249,7 +249,7 @@ mod identity {
 			&self,
 			receiver: IdentityNo,
 			chain: ChainId,
-		) -> Result<ChainAddress, Error> {
+		) -> Result<EncryptedAddress, Error> {
 			let receiver_identity = self
 				.number_to_identity
 				.get(receiver)
@@ -296,7 +296,11 @@ mod identity {
 
 		/// Adds an address for a given chain
 		#[ink(message)]
-		pub fn add_address(&mut self, chain: ChainId, address: ChainAddress) -> Result<(), Error> {
+		pub fn add_address(
+			&mut self,
+			chain: ChainId,
+			address: EncryptedAddress,
+		) -> Result<(), Error> {
 			let caller = self.env().caller();
 
 			let identity_no = self.identity_of.get(caller).map_or(Err(Error::NotAllowed), Ok)?;
@@ -316,7 +320,7 @@ mod identity {
 		pub fn update_address(
 			&mut self,
 			chain: ChainId,
-			address: ChainAddress,
+			address: EncryptedAddress,
 		) -> Result<(), Error> {
 			let caller = self.env().caller();
 

--- a/contracts/identity/tests.rs
+++ b/contracts/identity/tests.rs
@@ -19,8 +19,8 @@ fn constructor_works() {
 
 	assert_eq!(identity.latest_identity_no, 0);
 	assert_eq!(identity.admin, alice);
-	assert_eq!(identity.network_id_count, 0);
-	assert_eq!(identity.available_networks(), Vec::default());
+	assert_eq!(identity.chain_id_count, 0);
+	assert_eq!(identity.available_chains(), Vec::default());
 }
 
 #[ink::test]
@@ -79,20 +79,20 @@ fn add_address_to_identity_works() {
 	);
 
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://polkadot.com".to_string()],
 			account_type: AccountId32,
 		})
 		.is_ok());
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://moonbeam.com".to_string()],
 			account_type: AccountId32,
 		})
 		.is_ok());
 
-	let polkadot: NetworkId = 0;
-	let moonbeam: NetworkId = 1;
+	let polkadot: ChainId = 0;
+	let moonbeam: ChainId = 1;
 
 	// In reality this address would be encrypted before storing in the contract.
 	let encoded_address = alice.encode();
@@ -108,15 +108,15 @@ fn add_address_to_identity_works() {
 	let decoded_event = <Event as scale::Decode>::decode(&mut &last_event.data[..])
 		.expect("Failed to decode event");
 
-	let Event::AddressAdded(AddressAdded { identity_no, network, address }) = decoded_event else {
+	let Event::AddressAdded(AddressAdded { identity_no, chain, address }) = decoded_event else {
 		panic!("AddressAdded event should be emitted")
 	};
 
 	assert_eq!(identity_no, 0);
-	assert_eq!(network, polkadot);
+	assert_eq!(chain, polkadot);
 	assert_eq!(address, encoded_address);
 
-	// Cannot add an address for the same network twice.
+	// Cannot add an address for the same chain twice.
 	assert_eq!(
 		identity.add_address(polkadot, encoded_address.clone()),
 		Err(Error::AddressAlreadyAdded)
@@ -135,13 +135,13 @@ fn update_address_works() {
 
 	assert!(identity.create_identity().is_ok());
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://polkadot.com".to_string()],
 			account_type: AccountId32,
 		})
 		.is_ok());
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://moonbeam.com".to_string()],
 			account_type: AccountId32,
 		})
@@ -153,8 +153,8 @@ fn update_address_works() {
 		IdentityInfo { addresses: Default::default() }
 	);
 
-	let polkadot: NetworkId = 0;
-	let moonbeam: NetworkId = 1;
+	let polkadot: ChainId = 0;
+	let moonbeam: ChainId = 1;
 
 	let polkadot_address = alice.encode();
 
@@ -179,19 +179,19 @@ fn update_address_works() {
 	let decoded_event = <Event as scale::Decode>::decode(&mut &last_event.data[..])
 		.expect("Failed to decode event");
 
-	let Event::AddressUpdated(AddressUpdated { identity_no, network, updated_address }) =
+	let Event::AddressUpdated(AddressUpdated { identity_no, chain, updated_address }) =
 		decoded_event
 	else {
 		panic!("AddressUpdated event should be emitted")
 	};
 
 	assert_eq!(identity_no, 0);
-	assert_eq!(network, polkadot);
+	assert_eq!(chain, polkadot);
 	assert_eq!(updated_address, new_polkadot_address);
 
 	// Won't work since the identity doesn't have an address on the
 	// Moonbeam parachain.
-	assert_eq!(identity.update_address(moonbeam, alice.encode()), Err(Error::InvalidNetwork));
+	assert_eq!(identity.update_address(moonbeam, alice.encode()), Err(Error::InvalidChain));
 
 	// Charlie is not allowed to update to alice's identity.
 	set_caller::<DefaultEnvironment>(charlie);
@@ -206,7 +206,7 @@ fn remove_address_works() {
 
 	assert!(identity.create_identity().is_ok());
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://polkadot.com".to_string()],
 			account_type: AccountId32,
 		})
@@ -218,7 +218,7 @@ fn remove_address_works() {
 		IdentityInfo { addresses: Default::default() }
 	);
 
-	let polkadot: NetworkId = 0;
+	let polkadot: ChainId = 0;
 	// In reality this address would be encrypted before storing in the contract.
 	let encoded_address = alice.encode();
 
@@ -240,18 +240,18 @@ fn remove_address_works() {
 	let decoded_event = <Event as scale::Decode>::decode(&mut &last_event.data[..])
 		.expect("Failed to decode event");
 
-	let Event::AddressRemoved(AddressRemoved { identity_no, network }) = decoded_event else {
+	let Event::AddressRemoved(AddressRemoved { identity_no, chain }) = decoded_event else {
 		panic!("AddressRemoved event should be emitted")
 	};
 
 	assert_eq!(identity_no, 0);
-	assert_eq!(network, polkadot);
+	assert_eq!(chain, polkadot);
 
 	assert_eq!(identity.number_to_identity.get(0).unwrap(), IdentityInfo { addresses: vec![] });
 
-	// Cannot remove an address from a network that is not part of the
+	// Cannot remove an address from a chain that is not part of the
 	// identity.
-	assert_eq!(identity.remove_address(polkadot), Err(Error::InvalidNetwork));
+	assert_eq!(identity.remove_address(polkadot), Err(Error::InvalidChain));
 }
 
 #[ink::test]
@@ -263,7 +263,7 @@ fn remove_identity_works() {
 	assert!(identity.create_identity().is_ok());
 
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://polkadot.com".to_string()],
 			account_type: AccountId32,
 		})
@@ -277,7 +277,7 @@ fn remove_identity_works() {
 
 	// In reality this address would be encrypted before storing in the contract.
 	let encoded_address = alice.encode();
-	let polkadot: NetworkId = 0;
+	let polkadot: ChainId = 0;
 
 	assert!(identity.add_address(polkadot, encoded_address.clone()).is_ok());
 	assert_eq!(
@@ -315,7 +315,7 @@ fn address_size_limit_works() {
 
 	assert!(identity.create_identity().is_ok());
 	assert!(identity
-		.add_network(NetworkInfo {
+		.add_chain(ChainInfo {
 			rpc_urls: vec!["ws://polkadot.com".to_string()],
 			account_type: AccountId32,
 		})
@@ -330,7 +330,7 @@ fn address_size_limit_works() {
 }
 
 #[ink::test]
-fn add_network_works() {
+fn add_chain_works() {
 	let DefaultAccounts::<DefaultEnvironment> { alice, bob, .. } = get_default_accounts();
 
 	let mut identity = Identity::new();
@@ -339,9 +339,9 @@ fn add_network_works() {
 	let polkadot_rpc_urls = vec!["ws://polkadot.com".to_string()];
 	let kusama_rpc_urls = vec!["ws://polkadot.com".to_string()];
 
-	// Adding a network successful
+	// Adding a chain successful
 	assert!(identity
-		.add_network(NetworkInfo { rpc_urls: polkadot_rpc_urls.clone(), account_type: AccountId32 })
+		.add_chain(ChainInfo { rpc_urls: polkadot_rpc_urls.clone(), account_type: AccountId32 })
 		.is_ok());
 
 	// Check emitted events
@@ -350,42 +350,42 @@ fn add_network_works() {
 	let decoded_event = <Event as scale::Decode>::decode(&mut &last_event.data[..])
 		.expect("Failed to decode event");
 
-	let Event::NetworkAdded(NetworkAdded { network_id, rpc_urls, account_type }) = decoded_event
+	let Event::ChainAdded(ChainAdded { chain_id, rpc_urls, account_type }) = decoded_event
 	else {
-		panic!("NetworkAdded event should be emitted")
+		panic!("ChainAdded event should be emitted")
 	};
 
-	assert_eq!(network_id, 0);
+	assert_eq!(chain_id, 0);
 	assert_eq!(rpc_urls, polkadot_rpc_urls);
 	assert_eq!(account_type, AccountId32);
 
-	let info = NetworkInfo { rpc_urls: polkadot_rpc_urls.clone(), account_type: AccountId32 };
+	let info = ChainInfo { rpc_urls: polkadot_rpc_urls.clone(), account_type: AccountId32 };
 
 	// Check storage items updated
-	assert_eq!(identity.network_info_of.get(network_id), Some(info.clone()));
-	assert_eq!(identity.available_networks(), vec![(network_id, info)]);
-	assert_eq!(identity.network_id_count, 1);
+	assert_eq!(identity.chain_info_of.get(chain_id), Some(info.clone()));
+	assert_eq!(identity.available_chains(), vec![(chain_id, info)]);
+	assert_eq!(identity.chain_id_count, 1);
 
-	// Only the contract creator can add a new network
+	// Only the contract creator can add a new chain
 	set_caller::<DefaultEnvironment>(bob);
 	assert_eq!(
-		identity.add_network(NetworkInfo { rpc_urls: kusama_rpc_urls, account_type: AccountId32 }),
+		identity.add_chain(ChainInfo { rpc_urls: kusama_rpc_urls, account_type: AccountId32 }),
 		Err(Error::NotAllowed)
 	);
 
 	set_caller::<DefaultEnvironment>(alice);
 
-	// Rpc url of the network should not be too long
+	// Rpc url of the chain should not be too long
 	let long_rpc_urls: Vec<String> =
-		vec![String::from_utf8(vec![b'a'; NETWORK_RPC_URL_LIMIT + 1]).unwrap()];
+		vec![String::from_utf8(vec![b'a'; CHAIN_RPC_URL_LIMIT + 1]).unwrap()];
 	assert_eq!(
-		identity.add_network(NetworkInfo { rpc_urls: long_rpc_urls, account_type: AccountId32 }),
-		Err(Error::NetworkRpcUrlTooLong)
+		identity.add_chain(ChainInfo { rpc_urls: long_rpc_urls, account_type: AccountId32 }),
+		Err(Error::ChainRpcUrlTooLong)
 	);
 }
 
 #[ink::test]
-fn remove_network_works() {
+fn remove_chain_works() {
 	let DefaultAccounts::<DefaultEnvironment> { alice, bob, .. } = get_default_accounts();
 	let polkadot_rpc_urls = vec!["ws://polkadot.com".to_string()];
 	let account_type = AccountId32;
@@ -393,42 +393,42 @@ fn remove_network_works() {
 	let mut identity = Identity::new();
 	assert_eq!(identity.admin, alice);
 
-	let Ok(network_id) =
-		identity.add_network(NetworkInfo { rpc_urls: polkadot_rpc_urls, account_type })
+	let Ok(chain_id) =
+		identity.add_chain(ChainInfo { rpc_urls: polkadot_rpc_urls, account_type })
 	else {
-		panic!("Failed to add network")
+		panic!("Failed to add chain")
 	};
 
-	// Remove network: network doesn't exist
-	assert_eq!(identity.remove_network(network_id + 1), Err(Error::InvalidNetwork));
+	// Remove chain: chain doesn't exist
+	assert_eq!(identity.remove_chain(chain_id + 1), Err(Error::InvalidChain));
 
-	// Only the contract owner can remove a network
+	// Only the contract owner can remove a chain
 	set_caller::<DefaultEnvironment>(bob);
-	assert_eq!(identity.remove_network(network_id), Err(Error::NotAllowed));
+	assert_eq!(identity.remove_chain(chain_id), Err(Error::NotAllowed));
 
-	// Remove network successful
+	// Remove chain successful
 	set_caller::<DefaultEnvironment>(alice);
-	assert!(identity.remove_network(network_id).is_ok());
+	assert!(identity.remove_chain(chain_id).is_ok());
 
-	assert!(identity.network_info_of.get(0).is_none());
+	assert!(identity.chain_info_of.get(0).is_none());
 
-	assert!(identity.available_networks().is_empty());
+	assert!(identity.available_chains().is_empty());
 
 	// Check emitted events
 	let last_event = recorded_events().last().unwrap();
 	let decoded_event = <Event as scale::Decode>::decode(&mut &last_event.data[..])
 		.expect("Failed to decode event");
 
-	let Event::NetworkRemoved(NetworkRemoved { network_id: removed_network_id }) = decoded_event
+	let Event::ChainRemoved(ChainRemoved { chain_id: removed_chain_id }) = decoded_event
 	else {
-		panic!("NetworkRemoved event should be emitted")
+		panic!("ChainRemoved event should be emitted")
 	};
 
-	assert_eq!(removed_network_id, network_id);
+	assert_eq!(removed_chain_id, chain_id);
 }
 
 #[ink::test]
-fn update_network_works() {
+fn update_chain_works() {
 	let DefaultAccounts::<DefaultEnvironment> { alice, bob, .. } = get_default_accounts();
 	let polkadot_rpc = "ws://pokladot.com".to_string();
 	let kusama_rpc = "ws://kusama.com".to_string();
@@ -439,43 +439,43 @@ fn update_network_works() {
 	let mut identity = Identity::new();
 	assert_eq!(identity.admin, alice);
 
-	let Ok(polkadot_id) = identity.add_network(NetworkInfo {
+	let Ok(polkadot_id) = identity.add_chain(ChainInfo {
 		rpc_urls: vec![polkadot_rpc.clone()],
 		account_type: account_type.clone(),
 	}) else {
-		panic!("Failed to add network")
+		panic!("Failed to add chain")
 	};
 
 	assert!(identity
-		.add_network(NetworkInfo { rpc_urls: vec![kusama_rpc], account_type })
+		.add_chain(ChainInfo { rpc_urls: vec![kusama_rpc], account_type })
 		.is_ok());
 
-	// Only the contract owner can update a network
+	// Only the contract owner can update a chain
 	set_caller::<DefaultEnvironment>(bob);
 	assert_eq!(
-		identity.update_network(polkadot_id, Some(moonbeam_rpc.clone()), Some(AccountKey20)),
+		identity.update_chain(polkadot_id, Some(moonbeam_rpc.clone()), Some(AccountKey20)),
 		Err(Error::NotAllowed)
 	);
 
 	set_caller::<DefaultEnvironment>(alice);
 
 	// Rpc url should not be too long.
-	let long_rpc_url: String = String::from_utf8(vec![b'a'; NETWORK_RPC_URL_LIMIT + 1]).unwrap();
+	let long_rpc_url: String = String::from_utf8(vec![b'a'; CHAIN_RPC_URL_LIMIT + 1]).unwrap();
 	assert_eq!(
-		identity.update_network(polkadot_id, Some(long_rpc_url), None),
-		Err(Error::NetworkRpcUrlTooLong)
+		identity.update_chain(polkadot_id, Some(long_rpc_url), None),
+		Err(Error::ChainRpcUrlTooLong)
 	);
 
-	// Must be an existing network.
+	// Must be an existing chain.
 	assert_eq!(
-		identity.update_network(3, Some(moonbeam_rpc.clone()), None),
-		Err(Error::InvalidNetwork)
+		identity.update_chain(3, Some(moonbeam_rpc.clone()), None),
+		Err(Error::InvalidChain)
 	);
 
-	let new_rpc_url = "ws://new-network.com".to_string();
-	// Update network success.
+	let new_rpc_url = "ws://new-chain.com".to_string();
+	// Update chain success.
 	assert!(identity
-		.update_network(polkadot_id, Some(new_rpc_url.clone()), Some(AccountKey20))
+		.update_chain(polkadot_id, Some(new_rpc_url.clone()), Some(AccountKey20))
 		.is_ok());
 
 	// Check the emitted events
@@ -484,16 +484,16 @@ fn update_network_works() {
 	let decoded_event = <Event as scale::Decode>::decode(&mut &last_event.data[..])
 		.expect("Failed to decode event");
 
-	let Event::NetworkUpdated(NetworkUpdated {
-		network_id: network_updated,
+	let Event::ChainUpdated(ChainUpdated {
+		chain_id: chain_updated,
 		rpc_urls: updated_rpc,
 		account_type: updated_account_type,
 	}) = decoded_event
 	else {
-		panic!("NetworkUpdated event should be emitted")
+		panic!("ChainUpdated event should be emitted")
 	};
 
-	assert_eq!(network_updated, polkadot_id);
+	assert_eq!(chain_updated, polkadot_id);
 	assert_eq!(updated_rpc, vec![polkadot_rpc, new_rpc_url]);
 	assert_eq!(updated_account_type, AccountKey20);
 }
@@ -537,11 +537,11 @@ fn transfer_ownership_works() {
 
 	let mut identity = Identity::new();
 
-	let Ok(polkadot_id) = identity.add_network(NetworkInfo {
+	let Ok(polkadot_id) = identity.add_chain(ChainInfo {
 		rpc_urls: vec!["ws://polkadot.com".to_string()],
 		account_type: AccountId32,
 	}) else {
-		panic!("Failed to add network")
+		panic!("Failed to add chain")
 	};
 
 	assert!(identity.create_identity().is_ok());
@@ -613,54 +613,54 @@ fn transfer_ownership_fails_when_new_owner_has_an_identity() {
 }
 
 #[ink::test]
-fn init_with_networks_works() {
+fn init_with_chains_works() {
 	let polkadot_rpc = "ws://polkadot.com".to_string();
 	let kusama_rpc = "ws://kusama.com".to_string();
 	let moonbeam_rpc = "ws://moonbeam.com".to_string();
 	let astar_rpc = "ws://astar.com".to_string();
 
-	let networks = vec![
-		NetworkInfo { rpc_urls: vec![polkadot_rpc.clone()], account_type: AccountId32 },
-		NetworkInfo { rpc_urls: vec![kusama_rpc.clone()], account_type: AccountId32 },
-		NetworkInfo { rpc_urls: vec![moonbeam_rpc.clone()], account_type: AccountKey20 },
-		NetworkInfo { rpc_urls: vec![astar_rpc.clone()], account_type: AccountId32 },
+	let chains = vec![
+		ChainInfo { rpc_urls: vec![polkadot_rpc.clone()], account_type: AccountId32 },
+		ChainInfo { rpc_urls: vec![kusama_rpc.clone()], account_type: AccountId32 },
+		ChainInfo { rpc_urls: vec![moonbeam_rpc.clone()], account_type: AccountKey20 },
+		ChainInfo { rpc_urls: vec![astar_rpc.clone()], account_type: AccountId32 },
 	];
-	let identity = Identity::init_with_networks(networks);
+	let identity = Identity::init_with_chains(chains);
 
 	assert_eq!(
-		identity.network_info_of(0),
-		Some(NetworkInfo { rpc_urls: vec![polkadot_rpc.clone()], account_type: AccountId32 })
+		identity.chain_info_of(0),
+		Some(ChainInfo { rpc_urls: vec![polkadot_rpc.clone()], account_type: AccountId32 })
 	);
 	assert_eq!(
-		identity.network_info_of(1),
-		Some(NetworkInfo { rpc_urls: vec![kusama_rpc.clone()], account_type: AccountId32 })
+		identity.chain_info_of(1),
+		Some(ChainInfo { rpc_urls: vec![kusama_rpc.clone()], account_type: AccountId32 })
 	);
 	assert_eq!(
-		identity.network_info_of(2),
-		Some(NetworkInfo { rpc_urls: vec![moonbeam_rpc.clone()], account_type: AccountKey20 })
+		identity.chain_info_of(2),
+		Some(ChainInfo { rpc_urls: vec![moonbeam_rpc.clone()], account_type: AccountKey20 })
 	);
 	assert_eq!(
-		identity.network_info_of(3),
-		Some(NetworkInfo { rpc_urls: vec![astar_rpc.clone()], account_type: AccountId32 })
+		identity.chain_info_of(3),
+		Some(ChainInfo { rpc_urls: vec![astar_rpc.clone()], account_type: AccountId32 })
 	);
 
-	assert_eq!(identity.network_id_count, 4);
+	assert_eq!(identity.chain_id_count, 4);
 	assert_eq!(
-		identity.available_networks(),
+		identity.available_chains(),
 		vec![
-			(0, NetworkInfo { rpc_urls: vec![polkadot_rpc], account_type: AccountId32 }),
-			(1, NetworkInfo { rpc_urls: vec![kusama_rpc], account_type: AccountId32 }),
-			(2, NetworkInfo { rpc_urls: vec![moonbeam_rpc], account_type: AccountKey20 }),
-			(3, NetworkInfo { rpc_urls: vec![astar_rpc], account_type: AccountId32 })
+			(0, ChainInfo { rpc_urls: vec![polkadot_rpc], account_type: AccountId32 }),
+			(1, ChainInfo { rpc_urls: vec![kusama_rpc], account_type: AccountId32 }),
+			(2, ChainInfo { rpc_urls: vec![moonbeam_rpc], account_type: AccountKey20 }),
+			(3, ChainInfo { rpc_urls: vec![astar_rpc], account_type: AccountId32 })
 		]
 	);
 }
 
 #[ink::test]
-#[should_panic(expected = "Network rpc url is too long")]
-fn init_with_networks_fail() {
-	let rpc_url_long = String::from_utf8(vec![b'a'; NETWORK_RPC_URL_LIMIT + 1]).unwrap();
-	Identity::init_with_networks(vec![NetworkInfo {
+#[should_panic(expected = "Chain rpc url is too long")]
+fn init_with_chains_fail() {
+	let rpc_url_long = String::from_utf8(vec![b'a'; CHAIN_RPC_URL_LIMIT + 1]).unwrap();
+	Identity::init_with_chains(vec![ChainInfo {
 		rpc_urls: vec![rpc_url_long],
 		account_type: AccountId32,
 	}]);
@@ -673,11 +673,11 @@ fn getting_transaction_destination_works() {
 
 	let mut identity = Identity::new();
 
-	let Ok(polkadot_id) = identity.add_network(NetworkInfo {
+	let Ok(polkadot_id) = identity.add_chain(ChainInfo {
 		rpc_urls: vec!["ws://polkadot.com".to_string()],
 		account_type: AccountId32,
 	}) else {
-		panic!("Failed to add network")
+		panic!("Failed to add chain")
 	};
 
 	assert!(identity.create_identity().is_ok());
@@ -702,17 +702,17 @@ fn getting_transaction_destination_works() {
 	// Fails since the provided `identity_no` does not exist.
 	assert_eq!(identity.transaction_destination(42, polkadot_id), Err(Error::IdentityDoesntExist));
 
-	// Fails because alice does not have an address on the Moonbeam network.
-	let Ok(moonbeam_id) = identity.add_network(NetworkInfo {
+	// Fails because alice does not have an address on the Moonbeam chain.
+	let Ok(moonbeam_id) = identity.add_chain(ChainInfo {
 		rpc_urls: vec!["ws://moonbeam.com".to_string()],
 		account_type: AccountId32,
 	}) else {
-		panic!("Failed to add network")
+		panic!("Failed to add chain")
 	};
 
 	assert_eq!(
 		identity.transaction_destination(identity_no, moonbeam_id),
-		Err(Error::InvalidNetwork)
+		Err(Error::InvalidChain)
 	);
 }
 

--- a/contracts/identity/types.rs
+++ b/contracts/identity/types.rs
@@ -16,11 +16,7 @@ pub struct IdentityInfo {
 
 impl IdentityInfo {
 	/// Adds an address for the given chain
-	pub fn add_address(
-		&mut self,
-		chain: ChainId,
-		address: ChainAddress,
-	) -> Result<(), Error> {
+	pub fn add_address(&mut self, chain: ChainId, address: ChainAddress) -> Result<(), Error> {
 		ensure!(address.len() <= ADDRESS_SIZE_LIMIT, Error::AddressSizeExceeded);
 
 		ensure!(

--- a/contracts/identity/types.rs
+++ b/contracts/identity/types.rs
@@ -11,54 +11,54 @@ use ink::storage::traits::StorageLayout;
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
 pub struct IdentityInfo {
 	/// Each address is associated with a specific blockchain.
-	pub(crate) addresses: Vec<(NetworkId, NetworkAddress)>,
+	pub(crate) addresses: Vec<(ChainId, ChainAddress)>,
 }
 
 impl IdentityInfo {
-	/// Adds an address for the given network
+	/// Adds an address for the given chain
 	pub fn add_address(
 		&mut self,
-		network: NetworkId,
-		address: NetworkAddress,
+		chain: ChainId,
+		address: ChainAddress,
 	) -> Result<(), Error> {
 		ensure!(address.len() <= ADDRESS_SIZE_LIMIT, Error::AddressSizeExceeded);
 
 		ensure!(
-			!self.addresses.clone().into_iter().any(|address| address.0 == network),
+			!self.addresses.clone().into_iter().any(|address| address.0 == chain),
 			Error::AddressAlreadyAdded
 		);
-		self.addresses.push((network, address));
+		self.addresses.push((chain, address));
 
 		Ok(())
 	}
 
-	/// Updates the address of the given network
+	/// Updates the address of the given chain
 	pub fn update_address(
 		&mut self,
-		network: NetworkId,
-		new_address: NetworkAddress,
+		chain: ChainId,
+		new_address: ChainAddress,
 	) -> Result<(), Error> {
 		ensure!(new_address.len() <= ADDRESS_SIZE_LIMIT, Error::AddressSizeExceeded);
 
 		if let Some(position) =
-			self.addresses.clone().into_iter().position(|address| address.0 == network)
+			self.addresses.clone().into_iter().position(|address| address.0 == chain)
 		{
-			self.addresses[position] = (network, new_address);
+			self.addresses[position] = (chain, new_address);
 			Ok(())
 		} else {
-			Err(Error::InvalidNetwork)
+			Err(Error::InvalidChain)
 		}
 	}
 
-	/// Remove an address record by network
-	pub fn remove_address(&mut self, network: NetworkId) -> Result<(), Error> {
+	/// Remove an address record by chain
+	pub fn remove_address(&mut self, chain: ChainId) -> Result<(), Error> {
 		let old_count = self.addresses.len();
-		self.addresses.retain(|(net, _)| *net != network);
+		self.addresses.retain(|(net, _)| *net != chain);
 
 		let new_count = self.addresses.len();
 
 		if old_count == new_count {
-			Err(Error::InvalidNetwork)
+			Err(Error::InvalidChain)
 		} else {
 			Ok(())
 		}

--- a/contracts/identity/types.rs
+++ b/contracts/identity/types.rs
@@ -11,12 +11,12 @@ use ink::storage::traits::StorageLayout;
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
 pub struct IdentityInfo {
 	/// Each address is associated with a specific blockchain.
-	pub(crate) addresses: Vec<(ChainId, ChainAddress)>,
+	pub(crate) addresses: Vec<(ChainId, EncryptedAddress)>,
 }
 
 impl IdentityInfo {
 	/// Adds an address for the given chain
-	pub fn add_address(&mut self, chain: ChainId, address: ChainAddress) -> Result<(), Error> {
+	pub fn add_address(&mut self, chain: ChainId, address: EncryptedAddress) -> Result<(), Error> {
 		ensure!(address.len() <= ADDRESS_SIZE_LIMIT, Error::AddressSizeExceeded);
 
 		ensure!(
@@ -32,7 +32,7 @@ impl IdentityInfo {
 	pub fn update_address(
 		&mut self,
 		chain: ChainId,
-		new_address: ChainAddress,
+		new_address: EncryptedAddress,
 	) -> Result<(), Error> {
 		ensure!(new_address.len() <= ADDRESS_SIZE_LIMIT, Error::AddressSizeExceeded);
 


### PR DESCRIPTION
TODOs:

- [x] Rename every instance of the word network to the word chain. The reason for this is because when we say network we usually refer to an entire network of blockchains, e.g. the Polkadot or Kusama network containing all the parachains and the relay chain.
- [x] Rename `ChainAddress` to `EncryptedAddress` since the name `ChainAddress` can be misleading and in essence, doesn't really make any sense.
- [x] Make `NetworkId`(now called `ChainId`). The reason for this is explained here: #71 To achieve the api will have to change a bit since the admin will have to set the `ChainId` manually.

Closes: #71 