### PR TITLE
Add network property to ChainInfo

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -14,7 +14,9 @@ pub type IdentityNo = u32;
 pub type EncryptedAddress = Vec<u8>;
 
 /// Used to represent any blockchain in the Polkadot, Kusama or Rococo chain.
-pub type ChainId = u32;
+///
+/// We also need the network to differentiate two parachains with the same paraId.
+pub type ChainId = (u32, Network);
 
 /// We currently support these two address types since XCM is also supporting
 /// only these ones.
@@ -35,8 +37,6 @@ pub enum Network {
 #[derive(scale::Encode, scale::Decode, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
 pub struct ChainInfo {
-	/// The network to which the chain belongs.
-	pub network: Network,
 	/// We need to know the address type when making XCM transfers.
 	pub account_type: AccountType,
 }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -27,7 +27,16 @@ pub enum AccountType {
 
 #[derive(scale::Encode, scale::Decode, Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
+pub enum Network {
+	Polkadot,
+	Kusama,
+}
+
+#[derive(scale::Encode, scale::Decode, Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
 pub struct ChainInfo {
+	/// The network to which the chain belongs.
+	pub network: Network,
 	/// We need to know the address type when making XCM transfers.
 	pub account_type: AccountType,
 }

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -133,6 +133,8 @@ mod identity {
 		/// The `ChainId` that is associated with the newly added chain.
 		#[ink(topic)]
 		pub(crate) chain_id: ChainId,
+		/// The network to which the chain belongs.
+		pub(crate) network: Network,
 		/// The address type used on the chain.
 		pub(crate) account_type: AccountType,
 	}
@@ -383,9 +385,9 @@ mod identity {
 			self.chain_info_of.insert(chain_id, &info);
 			self.chain_ids.push(chain_id);
 
-			let ChainInfo { account_type } = info;
+			let ChainInfo { account_type, network } = info;
 
-			self.env().emit_event(ChainAdded { chain_id, account_type });
+			self.env().emit_event(ChainAdded { chain_id, account_type, network });
 
 			Ok(())
 		}

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -402,7 +402,8 @@ mod identity {
 			ensure!(caller == self.admin, Error::NotAllowed);
 
 			// Ensure that the given chain id exists
-			let mut info = self.chain_info_of.get(chain_id.clone()).map_or(Err(Error::InvalidChain), Ok)?;
+			let mut info =
+				self.chain_info_of.get(chain_id.clone()).map_or(Err(Error::InvalidChain), Ok)?;
 
 			if let Some(account_type) = new_address_type {
 				info.account_type = account_type;

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -262,14 +262,16 @@ mod identity {
 			}
 		}
 
-		/// A list of all the available chains each associated with a `ChainId`.
+		/// A list of all the available chains each associated with the associated
+		/// `ChainId`.
 		#[ink(message)]
-		pub fn available_chains(&self) -> Vec<(ChainId, ChainInfo)> {
+		pub fn available_chains(&self, network: Network) -> Vec<(u32, ChainInfo)> {
 			self.chain_ids
 				.clone()
 				.into_iter()
 				.map(|id| (id.clone(), self.chain_info_of(id)))
-				.filter_map(|(id, maybe_chain)| maybe_chain.map(|info| (id, info)))
+				.filter(|(id, _)| id.1 == network)
+				.filter_map(|(id, maybe_chain)| maybe_chain.map(|info| (id.0, info)))
 				.collect()
 		}
 

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -266,12 +266,13 @@ mod identity {
 
 		/// A list of all the available chains each associated with a `ChainId`.
 		#[ink(message)]
-		pub fn available_chains(&self) -> Vec<(ChainId, ChainInfo)> {
+		pub fn available_chains(&self, network: Network) -> Vec<(ChainId, ChainInfo)> {
 			self.chain_ids
 				.clone()
 				.into_iter()
 				.map(|id| (id, self.chain_info_of(id)))
 				.filter_map(|(id, maybe_chain)| maybe_chain.map(|info| (id, info)))
+				.filter(|(_, info)| info.network == network)
 				.collect()
 		}
 

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -61,7 +61,8 @@ mod identity {
 		/// so this storage value keeps track of that.
 		pub(crate) latest_identity_no: IdentityNo,
 
-		/// The chain information associated with a specific `ChainId`.
+		/// The chain information associated with a specific `ChainId` on the
+		/// specific network.
 		///
 		/// NOTE: This mapping is only modifiable by the admin.
 		pub(crate) chain_info_of: Mapping<ChainId, ChainInfo>,
@@ -133,8 +134,6 @@ mod identity {
 		/// The `ChainId` that is associated with the newly added chain.
 		#[ink(topic)]
 		pub(crate) chain_id: ChainId,
-		/// The network to which the chain belongs.
-		pub(crate) network: Network,
 		/// The address type used on the chain.
 		pub(crate) account_type: AccountType,
 	}
@@ -203,7 +202,6 @@ mod identity {
 				.into_iter()
 				.zip(chains.into_iter())
 				.for_each(|(chain_id, chain)| {
-					let chain_id = chain_id as ChainId;
 					chain_info_of.insert(chain_id, &chain);
 				});
 
@@ -266,13 +264,12 @@ mod identity {
 
 		/// A list of all the available chains each associated with a `ChainId`.
 		#[ink(message)]
-		pub fn available_chains(&self, network: Network) -> Vec<(ChainId, ChainInfo)> {
+		pub fn available_chains(&self) -> Vec<(ChainId, ChainInfo)> {
 			self.chain_ids
 				.clone()
 				.into_iter()
-				.map(|id| (id, self.chain_info_of(id)))
+				.map(|id| (id.clone(), self.chain_info_of(id)))
 				.filter_map(|(id, maybe_chain)| maybe_chain.map(|info| (id, info)))
-				.filter(|(_, info)| info.network == network)
 				.collect()
 		}
 
@@ -313,7 +310,7 @@ mod identity {
 
 			let mut identity_info = self.get_identity_info_of_caller(caller)?;
 
-			identity_info.add_address(chain, address.clone())?;
+			identity_info.add_address(chain.clone(), address.clone())?;
 			self.number_to_identity.insert(identity_no, &identity_info);
 
 			self.env().emit_event(AddressAdded { identity_no, chain, address });
@@ -334,7 +331,7 @@ mod identity {
 
 			let mut identity_info = self.get_identity_info_of_caller(caller)?;
 
-			identity_info.update_address(chain, address.clone())?;
+			identity_info.update_address(chain.clone(), address.clone())?;
 			self.number_to_identity.insert(identity_no, &identity_info);
 
 			self.env()
@@ -352,7 +349,7 @@ mod identity {
 
 			let mut identity_info = self.get_identity_info_of_caller(caller)?;
 
-			identity_info.remove_address(chain)?;
+			identity_info.remove_address(chain.clone())?;
 			self.number_to_identity.insert(identity_no, &identity_info);
 
 			self.env().emit_event(AddressRemoved { identity_no, chain });
@@ -383,12 +380,12 @@ mod identity {
 			// Only the contract owner can add a chain
 			ensure!(caller == self.admin, Error::NotAllowed);
 
-			self.chain_info_of.insert(chain_id, &info);
-			self.chain_ids.push(chain_id);
+			self.chain_info_of.insert(chain_id.clone(), &info);
+			self.chain_ids.push(chain_id.clone());
 
-			let ChainInfo { account_type, network } = info;
+			let ChainInfo { account_type } = info;
 
-			self.env().emit_event(ChainAdded { chain_id, account_type, network });
+			self.env().emit_event(ChainAdded { chain_id, account_type });
 
 			Ok(())
 		}
@@ -405,14 +402,14 @@ mod identity {
 			ensure!(caller == self.admin, Error::NotAllowed);
 
 			// Ensure that the given chain id exists
-			let mut info = self.chain_info_of.get(chain_id).map_or(Err(Error::InvalidChain), Ok)?;
+			let mut info = self.chain_info_of.get(chain_id.clone()).map_or(Err(Error::InvalidChain), Ok)?;
 
 			if let Some(account_type) = new_address_type {
 				info.account_type = account_type;
 			}
 
 			// Update storage items
-			self.chain_info_of.insert(chain_id, &info);
+			self.chain_info_of.insert(chain_id.clone(), &info);
 
 			self.env()
 				.emit_event(ChainUpdated { chain_id, account_type: info.account_type });
@@ -428,11 +425,11 @@ mod identity {
 			ensure!(caller == self.admin, Error::NotAllowed);
 
 			// Ensure that the given `chain_id` exists
-			let chain = self.chain_info_of.get(chain_id);
+			let chain = self.chain_info_of.get(chain_id.clone());
 			ensure!(chain.is_some(), Error::InvalidChain);
 
-			self.chain_info_of.remove(chain_id);
-			self.chain_ids.retain(|&c_id| c_id != chain_id);
+			self.chain_info_of.remove(chain_id.clone());
+			self.chain_ids.retain(|c_id| *c_id != chain_id.clone());
 
 			self.env().emit_event(ChainRemoved { chain_id });
 

--- a/contracts/identity/tests.rs
+++ b/contracts/identity/tests.rs
@@ -20,7 +20,8 @@ fn constructor_works() {
 	assert_eq!(identity.latest_identity_no, 0);
 	assert_eq!(identity.admin, alice);
 	assert_eq!(identity.chain_ids, vec![]);
-	assert_eq!(identity.available_chains(), Vec::default());
+	assert_eq!(identity.available_chains(Polkadot), Vec::default());
+	assert_eq!(identity.available_chains(Kusama), Vec::default());
 }
 
 #[ink::test]
@@ -334,7 +335,7 @@ fn add_chain_works() {
 
 	// Check storage items updated
 	assert_eq!(identity.chain_info_of.get(chain_id.clone()), Some(info.clone()));
-	assert_eq!(identity.available_chains(), vec![(chain_id, info)]);
+	assert_eq!(identity.available_chains(Kusama), vec![(chain_id.0, info)]);
 	assert_eq!(identity.chain_ids, vec![(0, Kusama)]);
 
 	// Only the contract creator can add a new chain
@@ -374,7 +375,7 @@ fn remove_chain_works() {
 
 	assert!(identity.chain_info_of.get(chain_id.clone()).is_none());
 
-	assert!(identity.available_chains().is_empty());
+	assert!(identity.available_chains(Kusama).is_empty());
 
 	// Check emitted events
 	let last_event = recorded_events().last().unwrap();
@@ -584,13 +585,38 @@ fn init_with_chains_works() {
 
 	assert_eq!(identity.chain_ids, chain_ids);
 	assert_eq!(
-		identity.available_chains(),
+		identity.available_chains(Polkadot),
 		vec![
-			((0, Polkadot), ChainInfo { account_type: AccountId32 }),
-			((2000, Polkadot), ChainInfo { account_type: AccountId32 }),
-			((2004, Polkadot), ChainInfo { account_type: AccountKey20 }),
-			((2006, Polkadot), ChainInfo { account_type: AccountId32 })
+			(0, ChainInfo { account_type: AccountId32 }),
+			(2000, ChainInfo { account_type: AccountId32 }),
+			(2004, ChainInfo { account_type: AccountKey20 }),
+			(2006, ChainInfo { account_type: AccountId32 })
 		]
+	);
+}
+
+#[ink::test]
+fn available_chains_works() {
+	let chains = vec![
+		ChainInfo { account_type: AccountId32 },
+		ChainInfo { account_type: AccountId32 },
+		ChainInfo { account_type: AccountKey20 },
+		ChainInfo { account_type: AccountId32 },
+	];
+	let chain_ids = vec![(0, Polkadot), (2000, Polkadot), (2004, Polkadot), (2006, Kusama)];
+	let identity = Identity::init_with_chains(chains, chain_ids);
+
+	assert_eq!(
+		identity.available_chains(Polkadot),
+		vec![
+			(0, ChainInfo { account_type: AccountId32 }),
+			(2000, ChainInfo { account_type: AccountId32 }),
+			(2004, ChainInfo { account_type: AccountKey20 }),
+		]
+	);
+	assert_eq!(
+		identity.available_chains(Kusama),
+		vec![(2006, ChainInfo { account_type: AccountId32 })]
 	);
 }
 

--- a/contracts/identity/tests.rs
+++ b/contracts/identity/tests.rs
@@ -20,7 +20,8 @@ fn constructor_works() {
 	assert_eq!(identity.latest_identity_no, 0);
 	assert_eq!(identity.admin, alice);
 	assert_eq!(identity.chain_ids, vec![]);
-	assert_eq!(identity.available_chains(), Vec::default());
+	assert_eq!(identity.available_chains(Polkadot), Vec::default());
+	assert_eq!(identity.available_chains(Kusama), Vec::default());
 }
 
 #[ink::test]
@@ -338,7 +339,7 @@ fn add_chain_works() {
 
 	// Check storage items updated
 	assert_eq!(identity.chain_info_of.get(chain_id), Some(info.clone()));
-	assert_eq!(identity.available_chains(), vec![(chain_id, info)]);
+	assert_eq!(identity.available_chains(Kusama), vec![(chain_id, info)]);
 	assert_eq!(identity.chain_ids, vec![0]);
 
 	// Only the contract creator can add a new chain
@@ -379,7 +380,7 @@ fn remove_chain_works() {
 
 	assert!(identity.chain_info_of.get(0).is_none());
 
-	assert!(identity.available_chains().is_empty());
+	assert!(identity.available_chains(Kusama).is_empty());
 
 	// Check emitted events
 	let last_event = recorded_events().last().unwrap();
@@ -590,7 +591,7 @@ fn init_with_chains_works() {
 
 	assert_eq!(identity.chain_ids, chain_ids);
 	assert_eq!(
-		identity.available_chains(),
+		identity.available_chains(Kusama),
 		vec![
 			(0, ChainInfo { account_type: AccountId32, network: Kusama }),
 			(2000, ChainInfo { account_type: AccountId32, network: Kusama }),
@@ -649,6 +650,31 @@ fn getting_transaction_destination_works() {
 	assert_eq!(
 		identity.transaction_destination(identity_no, moonbeam_id),
 		Err(Error::InvalidChain)
+	);
+}
+
+#[ink::test]
+fn available_chains_works() {
+	let chains = vec![
+		ChainInfo { account_type: AccountId32, network: Polkadot },
+		ChainInfo { account_type: AccountId32, network: Polkadot },
+		ChainInfo { account_type: AccountKey20, network: Polkadot },
+		ChainInfo { account_type: AccountId32, network: Kusama },
+	];
+	let chain_ids = vec![0, 2000, 2004, 2006];
+	let identity = Identity::init_with_chains(chains, chain_ids);
+
+	assert_eq!(
+		identity.available_chains(Polkadot),
+		vec![
+			(0, ChainInfo { account_type: AccountId32, network: Polkadot }),
+			(2000, ChainInfo { account_type: AccountId32, network: Polkadot }),
+			(2004, ChainInfo { account_type: AccountKey20, network: Polkadot }),
+		]
+	);
+	assert_eq!(
+		identity.available_chains(Kusama),
+		vec![(2006, ChainInfo { account_type: AccountId32, network: Kusama })]
 	);
 }
 


### PR DESCRIPTION
This is needed since we will only have one contract deployed that will contain the addresses for both Kusama and Polkadot.